### PR TITLE
Links to member company websites

### DIFF
--- a/src/views/Story.vue
+++ b/src/views/Story.vue
@@ -35,7 +35,9 @@
                 <div class="col-md-5">
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-540.png" class="img-fluid" />
+                            <a href="https://540.co">
+                                <img src="@/assets/logo-540.png" class="img-fluid" alt="540" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe in the value of moving fast, showing capabilities (rather than talking about them), and doing whatever it takes to make our government operate in a more effective manner. The Coalition enables us to collaborate, share ideas, and further those ideals.”</p> 
@@ -44,7 +46,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-adhoc.png" class="img-fluid" />
+                            <a href="https://adhocteam.us">
+                                <img src="@/assets/logo-adhoc.png" class="img-fluid" alt="Ad Hoc" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We look forward to working with the the coalition to make a difference in the daily lives of users through improved interactions with government digital services built specifically for them.”</p> 
@@ -53,7 +57,9 @@
 
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-agilesix.png" class="img-fluid" />
+                            <a href="https://www.agile6.com">
+                                <img src="@/assets/logo-agilesix.png" class="img-fluid" alt="Agile Six" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe that strong teams are built on trust and agility. When someone tells you that they’ve “Got Your Six,” it means they’re watching your back. Knowing other member firms have our six means we can focus on transforming the working relationship between government and the private sector – which we believe will deliver better digital experiences for our citizens.”</p> 
@@ -62,7 +68,9 @@
 
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-civicactions.png" class="img-fluid" />
+                            <a href="https://civicactions.com/">
+                                <img src="@/assets/logo-civicactions.png" class="img-fluid" alt="Civic Actions" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We’re honored to be part of a strong network of firms who embrace the values of free and open-source software, knowledge sharing, collaboration, and contributing back while fostering a culture of openness and learning in government to build the next generation of modern public services.”</p> 
@@ -71,7 +79,9 @@
 
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-exygy.png" class="img-fluid" />
+                            <a href="https://exygy.com/">
+                                <img src="@/assets/logo-exygy.png" class="img-fluid" alt="Exygy" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe in using our skills—human-centered design, iterative agile software development, and modern product approaches—to foster healthy and resilient communities. We’re part of the coalition because we care about seeing more large-scale government services designed for inclusion, co-created with people and communities who need them most.”</p> 
@@ -80,7 +90,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-fearless.png" class="img-fluid" />
+                            <a href="http://fearless.tech">
+                                <img src="@/assets/logo-fearless.png" class="img-fluid" alt="Fearless" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe that the government has the potential to be better, and we want to help influence that change from the ground up. Our vision is to create a world where good software powers the things that matter, so we measure our success by our positive impact on the people in our communities.”</p> 
@@ -89,7 +101,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-flexion.png" class="img-fluid" />
+                            <a href="https://www.flexion.us/">
+                                <img src="@/assets/logo-flexion.png" class="img-fluid" alt="Flexion" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We have the strong belief that providing exceptional, accessible, and user-centric digital capabilities to the government will improve people’s everyday lives. Partnering with other innovative, agile, and forward-thinking firms will just accelerate and magnify the difference we can make.”</p> 
@@ -98,7 +112,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-mediabarn.png" class="img-fluid" />
+                            <a href="https://mediabarninc.com/">
+                                <img src="@/assets/logo-mediabarn.png" class="img-fluid" alt="Mediabarn" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We participate in this coalition and believe in its mission because we feel the government (at all levels), and by extension all people, deserve to be served by companies who take a modern, efficient, and honest approach to providing digital goods and services.”</p> 
@@ -109,7 +125,9 @@
                 <div class="col-md-5">
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-mo.png" class="img-fluid" />
+                            <a href="https://www.themostudio.com/">
+                                <img src="@/assets/logo-mo.png" class="img-fluid" alt="MO Studio" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe that we can help the government ask the right questions, find the right answers, conceptualize and co-design what the experience can become, and build solutions that delight the government’s customers—the public. We don’t want to play by the rules, but change how the game is played.”</p> 
@@ -118,7 +136,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-nava.png" class="img-fluid" />
+                            <a href="https://www.navapbc.com/">
+                                <img src="@/assets/logo-nava.png" class="img-fluid" alt="Nava Public Benefit Corporation" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“As a public benefit corporation, Nava is driven not just by profit, but also by our mission to build government software that well serves the American public. We are proud to be charter members of the Digital Services Coalition because our collective work shows that by putting the American people and civil servants at the center, it’s possible to radically improve how we deliver government services.”</p> 
@@ -127,7 +147,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-oddball.png" class="img-fluid" />
+                            <a href="https://oddball.io/">
+                                <img src="@/assets/logo-oddball.png" class="img-fluid" alt="Oddball" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We believe this group represents a unique and new way of doing business by focusing on quality, long-term relationships and delivering value to our clients. We’re excited to be part of this mission.”</p> 
@@ -136,7 +158,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-andpartners.png" class="img-fluid" />
+                            <a href="https://www.andpartners.io/">
+                                <img src="@/assets/logo-andpartners.png" class="img-fluid" alt="And Partners" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We are true believers that technology, policy, and a critical eye to the challenges that society faces can help bring about equality and improve all of our ways of life. We partner with bold organizations to design, build, and transform digital services that deliver positive customer outcomes and disrupt the status quo.”</p> 
@@ -145,7 +169,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-skylight.png" class="img-fluid" />
+                            <a href="https://skylight.digital/">
+                                <img src="@/assets/logo-skylight.png" class="img-fluid" alt="Skylight"/>
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“Our mission is to make government work in a digital world. We can’t imagine a better way of doing that than being part of an ecosystem of like-minded companies.”</p> 
@@ -154,7 +180,9 @@
 
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-thesocompany.png" class="img-fluid" />
+                            <a href="https://www.thesocompany.com/">
+                                <img src="@/assets/logo-thesocompany.png" class="img-fluid" alt="The So Company" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“We’re part of the Digital Services Coalition to extend our mission of improving services quickly, intelligently, and efficiently and to collaborate with others that want to provide these same service delivery promises. True change can’t be done alone.”</p> 
@@ -163,7 +191,9 @@
 
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-stsi.png" class="img-fluid" />
+                            <a href="https://stsiinc.com/">
+                                <img src="@/assets/logo-stsi.png" class="img-fluid" alt="STSI" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“Government missions make an impact on people’s lives. Software can be the ‘force multiplier’ to execute those missions. We believe that the government deserves the best in technology and talent in order to be as effective as possible.”</p> 
@@ -172,7 +202,9 @@
                     
                     <div class="row mt-5">
                         <div class="col-md-4 col-2">
-                            <img src="@/assets/logo-truss.png" class="img-fluid" />
+                            <a href="https://truss.works/">
+                                <img src="@/assets/logo-truss.png" class="img-fluid" alt="Truss" />
+                            </a>
                         </div>
                         <div class="col-md-8 col-10">
                             <p>“The public has come to expect more because of the digital services they effortlessly enjoy every day. We want to help bridge the gap between public expectation and government delivery by improving procurement, design, and build processes to deliver high-value, modern solutions.”</p> 


### PR DESCRIPTION
Added member company website links on Story page using existing logo images.  Also added alt text to images.

![dsc-member-company-links](https://user-images.githubusercontent.com/54035677/80259056-91776400-8639-11ea-9fcf-8eb85e59c606.gif)
