### PR TITLE
Upgade jquery to v 3.5.1; Fixes bootstrap collapse behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5726,6 +5726,11 @@
         "through": "^2.3.6"
       }
     },
+    "install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA=="
+    },
     "internal-ip": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
@@ -6111,9 +6116,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-levenshtein": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
-    "jquery": "^3.5.0",
+    "install": "^0.13.0",
+    "jquery": "^3.5.1",
     "popper.js": "^1.14.6",
     "register-service-worker": "^1.5.2",
     "vee-validate": "^2.1.7",


### PR DESCRIPTION
Looks like the upgrade to jquery 3.5.0 broke this bootstrap collapsible menu behavior.  For more information, see issue #30553 on bootstrap github:

https://github.com/twbs/bootstrap/issues/30553

Upgrading our version of jquery to 3.5.1 seems to resolve this bug on the DSC site.